### PR TITLE
Tracing improvements

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
   "repository": "https://github.com/Matechs-Garage/effect-ts.git",
   "sideEffects": false,
   "dependencies": {
-    "@effect-ts/system": "^0.9.5"
+    "@effect-ts/system": "^0.9.5",
+    "@effect-ts/tracing-utils": "^0.2.3"
   },
   "config": {
     "modules": [

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -26,7 +26,8 @@
   "repository": "https://github.com/Matechs-Garage/effect-ts.git",
   "sideEffects": false,
   "dependencies": {
-    "@effect-ts/core": "^0.11.5"
+    "@effect-ts/core": "^0.11.5",
+    "@effect-ts/tracing-utils": "^0.2.3"
   },
   "peerDependencies": {
     "jest": "^26.4.2"

--- a/packages/monocle/package.json
+++ b/packages/monocle/package.json
@@ -26,7 +26,8 @@
   "repository": "https://github.com/Matechs-Garage/effect-ts.git",
   "sideEffects": false,
   "dependencies": {
-    "@effect-ts/core": "^0.11.5"
+    "@effect-ts/core": "^0.11.5",
+    "@effect-ts/tracing-utils": "^0.2.3"
   },
   "config": {
     "modules": [

--- a/packages/morphic/package.json
+++ b/packages/morphic/package.json
@@ -27,7 +27,8 @@
   "sideEffects": false,
   "dependencies": {
     "@effect-ts/core": "^0.11.5",
-    "@effect-ts/monocle": "^0.10.5"
+    "@effect-ts/monocle": "^0.10.5",
+    "@effect-ts/tracing-utils": "^0.2.3"
   },
   "config": {
     "modules": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,8 @@
   "repository": "https://github.com/Matechs-Garage/effect-ts.git",
   "sideEffects": false,
   "dependencies": {
-    "@effect-ts/core": "^0.11.5"
+    "@effect-ts/core": "^0.11.5",
+    "@effect-ts/tracing-utils": "^0.2.3"
   },
   "config": {
     "modules": [

--- a/packages/tracing-plugin/src/tracer.ts
+++ b/packages/tracing-plugin/src/tracer.ts
@@ -51,8 +51,11 @@ export default function tracer(
         const traceF = factory.createUniqueName("trace")
         const traced = new Set<string>()
         const fileVar = factory.createUniqueName("fileName")
-        const traceVar = factory.createUniqueName("$trace")
         const tracing = factory.createUniqueName("tracing")
+        const traceVar = factory.createPropertyAccessExpression(
+          tracing,
+          factory.createIdentifier("tracingSymbol")
+        )
 
         const isModule =
           sourceFile.statements.find((s) => /(import|export)/.test(s.getText())) != null
@@ -384,21 +387,6 @@ export default function tracer(
           )
         )
 
-        const traceNode = factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                traceVar,
-                undefined,
-                undefined,
-                factory.createStringLiteral("$trace")
-              )
-            ],
-            ts.NodeFlags.Const
-          )
-        )
-
         const traceFNode = factory.createFunctionDeclaration(
           undefined,
           undefined,
@@ -465,7 +453,6 @@ export default function tracer(
               ),
               factory.createStringLiteral("@effect-ts/tracing-utils")
             ),
-            traceNode,
             fileNode,
             traceFNode,
             ...visited.statements

--- a/packages/tracing-plugin/src/tracer.ts
+++ b/packages/tracing-plugin/src/tracer.ts
@@ -387,55 +387,25 @@ export default function tracer(
           )
         )
 
-        const traceFNode = factory.createFunctionDeclaration(
+        const traceFNode = factory.createVariableStatement(
           undefined,
-          undefined,
-          undefined,
-          traceF,
-          undefined,
-          [
-            factory.createParameterDeclaration(
-              undefined,
-              undefined,
-              undefined,
-              factory.createIdentifier("f"),
-              undefined,
-              undefined,
-              undefined
-            ),
-            factory.createParameterDeclaration(
-              undefined,
-              undefined,
-              undefined,
-              factory.createIdentifier("t"),
-              undefined,
-              undefined,
-              undefined
-            )
-          ],
-          undefined,
-          factory.createBlock(
+          factory.createVariableDeclarationList(
             [
-              factory.createIfStatement(
-                factory.createIdentifier("f"),
-                factory.createExpressionStatement(
-                  factory.createBinaryExpression(
-                    factory.createElementAccessExpression(
-                      factory.createIdentifier("f"),
-                      traceVar
-                    ),
-                    factory.createToken(ts.SyntaxKind.EqualsToken),
-                    factory.createBinaryExpression(
-                      fileVar,
-                      factory.createToken(ts.SyntaxKind.PlusToken),
-                      factory.createIdentifier("t")
-                    )
-                  )
+              factory.createVariableDeclaration(
+                traceF,
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    tracing,
+                    factory.createIdentifier("traceFnForFile")
+                  ),
+                  undefined,
+                  [fileVar]
                 )
-              ),
-              factory.createReturnStatement(factory.createIdentifier("f"))
+              )
             ],
-            true
+            ts.NodeFlags.Const
           )
         )
 

--- a/packages/tracing-utils/src/index.ts
+++ b/packages/tracing-utils/src/index.ts
@@ -1,8 +1,10 @@
 import { isTracingEnabled } from "./Global"
 
+export const tracingSymbol = "$trace"
+
 export function traceAs<F extends Function>(g: any, f: F): F {
-  if (g["$trace"] && isTracingEnabled()) {
-    f["$trace"] = g["$trace"]
+  if (g[tracingSymbol] && isTracingEnabled()) {
+    f[tracingSymbol] = g[tracingSymbol]
   }
   return f
 }
@@ -11,14 +13,14 @@ export function traceCall<F extends Function>(call: F, trace: string): F {
   if (!isTracingEnabled()) {
     return call
   }
-  const y = call["$trace"]
+  const y = call[tracingSymbol]
   const g = ((...args: any[]) => {
-    call["$trace"] = trace
+    call[tracingSymbol] = trace
     const x = call(...args)
-    call["$trace"] = y
+    call[tracingSymbol] = y
     return x
   }) as any
-  g["$trace"] = y
+  g[tracingSymbol] = y
   return g
 }
 

--- a/packages/tracing-utils/src/index.ts
+++ b/packages/tracing-utils/src/index.ts
@@ -2,6 +2,14 @@ import { isTracingEnabled } from "./Global"
 
 export const tracingSymbol = "$trace"
 
+export const traceFnForFile = (file: string) => <F extends Function>(
+  f: F,
+  t: string
+): F => {
+  if (f) f[tracingSymbol] = file + t
+  return f
+}
+
 export function traceAs<F extends Function>(g: any, f: F): F {
   if (g[tracingSymbol] && isTracingEnabled()) {
     f[tracingSymbol] = g[tracingSymbol]


### PR DESCRIPTION
minor changes reducing number of duplicated functions. was hoping to add one more, but that breaks webpack shaking

Names for exported variables could be changed:
  * `traceFnForFile`
  * `tracingSymbol`